### PR TITLE
Add support for set_ntp_server

### DIFF
--- a/norbit/include/norbit/norbit_connection.h
+++ b/norbit/include/norbit/norbit_connection.h
@@ -39,6 +39,7 @@ struct ConnectionParams {
   std::string norbit_watercolumn_topic;
   std::string watercolumn_topic;
   double cmd_timeout;
+  double disconnect_timeout;
   std::map<std::string, std::string> startup_settings;
   std::map<std::string, std::string> shutdown_settings;
 

--- a/norbit/src/norbit_connection.cpp
+++ b/norbit/src/norbit_connection.cpp
@@ -216,7 +216,9 @@ norbit_msgs::CmdResp NorbitConnection::sendCmd(const std::string &cmd,
 
 void NorbitConnection::listenForCmd() {
 
-  boost::asio::async_read_until(*sockets_.cmd, cmd_resp_buffer_, "\r\n",
+  // Most commands are echoed with 0x0d 0x0a (\r\n), but
+  // set_ntp_server is termianted with 0x0a only.
+  boost::asio::async_read_until(*sockets_.cmd, cmd_resp_buffer_, "\n",
                                 boost::bind(&NorbitConnection::receiveCmd, this,
                                             boost::asio::placeholders::error));
 }

--- a/norbit/src/norbit_connection.cpp
+++ b/norbit/src/norbit_connection.cpp
@@ -391,20 +391,12 @@ void NorbitConnection::spin_once() {
 }
 
 void NorbitConnection::spin() {
-
-  do {
-
-    if(shutdown_){
-      ROS_WARN("[%s] shutting down:  executing shutdown parameters",ros::this_node::getName().c_str());
-      for (auto param : params_.shutdown_settings) {
-        sendCmd(param.first, param.second);
-        ros::shutdown();
-      }
-    }else{
-      spin_once();
-    }
-  }while (!shutdown_);
-
-
-
+  while (!shutdown_) {
+    spin_once();
+  }
+  ROS_WARN("[%s] shutting down:  executing shutdown parameters",ros::this_node::getName().c_str());
+  for (auto param : params_.shutdown_settings) {
+    sendCmd(param.first, param.second);
+  }
+  ros::shutdown();
 }


### PR DESCRIPTION
Hi @CaptKrasno -- we're using a Norbit on NUI, and I wound up needing to make some changes to the driver for it to work with our rather power-constrained ops:
* We don't have it powered on ascent/descent, which means that if the fiber breaks the driver needs to set its NTP server automatically when we power on the multibeam, rather than via the Windows GUI. This was an annoying one to track down, and seems like a bug in the Norbit firmware. (WHY would you use only 0x0a for one message, but 0x0d 0x0a for the rest?!?)
* We'll be power-cycling it a lot, so I tried to clean up the reconfiguration process (I'd been seeing some ugliness on the bench related to how connection timeout monitoring intersected with configuring the instrument.)

I'm also seeing some weirdness where it will spew hundreds of messages "Invalid version detected expected 4, got NNNN", while still seeming to parse the expected amount of data. tcpdump/wireshark wasn't illuminating (all the packets I captured from the sonar looked good, and there weren't any extras.) I may or may not take a closer look at that tomorrow.

